### PR TITLE
fix the broken recycle handling with busy main thread

### DIFF
--- a/src/discharge-checker.ts
+++ b/src/discharge-checker.ts
@@ -13,10 +13,13 @@ export class DischargeChecker {
   }
 
   private doCheck(t: number) {
-    if (t - this.checkerCycleStartTs >= 168) {
-      const numToDischarge = Math.ceil(this.scheduler.idleCount - this.accumulatedIdleCount / this.totalChecksOfCycle)
+    if (
+      this.totalChecksOfCycle /* only consider discharging when there's meaningful data */ &&
+      t - this.checkerCycleStartTs >= 168
+    ) {
+      const numToDischarge = Math.ceil(this.accumulatedIdleCount / this.totalChecksOfCycle);
 
-      if (numToDischarge > 0) {
+      if (numToDischarge >= this.scheduler.idleCount) {
         this.scheduler.discharge(numToDischarge);
       }
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -32,7 +32,7 @@ export class Handler<I, O> {
       if (this.retireRequested) {
         this.destroy();
       } else {
-        this.scheduler.handleQueuedRequest(this);
+        this.working = this.scheduler.handleQueuedRequest(this);
       }
     };
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -93,11 +93,15 @@ export class Scheduler<I, O> {
       if (nextReq) {
         handler.handleRequest(nextReq);
         this.busyHandlers.add(handler.id);
+
+        return true;
       } else {
         this.busyHandlers.delete(handler.id);
         this.idleHandlers.push(handler.id);
       }
     }
+
+    return false;
   }
 
   public kill() {
@@ -113,7 +117,7 @@ export class Scheduler<I, O> {
   }
 
   public discharge(numToDischarge: number) {
-    while (this.idleCount > 0 && numToDischarge--) {
+    while (this.idleCount > this.requestQueue.length && numToDischarge--) {
       const handlerIdToDischarge = this.idleHandlers.pop();
       const handlerToDischarge = this.handlers.get(handlerIdToDischarge)!;
 


### PR DESCRIPTION
+ when the main thread is quite occupied and results extremely low frame rate, the handler recycling logic can go into an infinite looping and blocks handling new incoming requests. Thus, relax the timing to trigger a recycle attempt.