### PR TITLE
add support to transferable

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -11,9 +11,9 @@ export class Handler<I, O> {
     private _id: string
   ) {}
 
-  public handle(req: IQueueRequest<I, O>["details"]) {
+  public handle(req: IQueueRequest<I, O>["details"], transferred: IQueueRequest<I, O>["transferred"]) {
     return new Promise<TInterruptableReq<O>>((resolve) => {
-      this.handleRequest({ details: req, report: resolve });
+      this.handleRequest({ details: req, transferred, report: resolve });
     });
   }
 
@@ -25,7 +25,7 @@ export class Handler<I, O> {
     this.worker.terminate();
   }
 
-  public handleRequest({ details, report }: IQueueRequest<I, O>) {
+  public handleRequest({ details, transferred, report }: IQueueRequest<I, O>) {
     this.working = true;
 
     const msgHandler = ({ data }: MessageEvent) => {
@@ -41,7 +41,7 @@ export class Handler<I, O> {
     };
 
     this.worker.addEventListener("message", msgHandler);
-    this.worker.postMessage(details);
+    this.worker.postMessage(details, transferred);
   }
 
   public retire() {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -40,16 +40,16 @@ export class Scheduler<I, O> {
     this.ownHandlerIds = new Set<string>();
   }
 
-  public doRequest = (req: I) => {
+  public doRequest = (req: I, transferred?: IQueueRequest<I, O>["transferred"]) => {
     const handler = this.getHandler();
     let result: Promise<TInterruptableReq<O>>;
     const qReq: IQueueRequest<I, O>["details"] = { ...req };
 
     if (!handler) {
-      result = this.arrangeRequest(qReq);
+      result = this.arrangeRequest(qReq, transferred);
     } else {
       this.busyHandlers.add(handler.id);
-      result = handler.handle(qReq);
+      result = handler.handle(qReq, transferred);
     }
 
     return result;
@@ -71,7 +71,7 @@ export class Scheduler<I, O> {
     return this.handlers.get(handlerId);
   }
 
-  private arrangeRequest(req: IQueueRequest<I, O>["details"]) {
+  private arrangeRequest(req: IQueueRequest<I, O>["details"], transferred: IQueueRequest<I, O>["transferred"]) {
     let report: IQueueRequest<I, O>["report"];
 
     const deferredRequestResult = new Promise<TInterruptableReq<O>>((res) => {
@@ -80,6 +80,7 @@ export class Scheduler<I, O> {
 
     this.requestQueue.push({
       details: req,
+      transferred,
       report,
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type TInterruptableReq<T> = T | typeof REQ_EARLY_TERMINATION_TOKEN;
 
 export interface IQueueRequest<I, O> {
   details: I;
+  transferred?: Transferable[];
   report: (data: TInterruptableReq<O>) => void;
 }
 


### PR DESCRIPTION
With this change, one can now specify transferred object list as how `postMessage` is used:
```ts
...

const swarmed = swarm(() => new Worker("my-data-cruncher.ts"));

const msg = {
  data: new ArrayBuffer(8 * 1024 * 1024)
};

swarmed(msg, [msg.data]).then(
  result => console.log(msg.data === undefined) // 'true' should be logged in the console.
);
```
