### PR TITLE
add new configuration parameters for controlling worker spawning/recy…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { Scheduler } from "./scheduler";
-import { TWorkerMaker } from "./types";
+import { TWorkerMaker, IConfigOpts } from "./types";
 
 export { REQ_EARLY_TERMINATION_TOKEN } from "./constants";
-export { TWorkerMaker } from "./types";
+export { TWorkerMaker, IConfigOpts } from "./types";
 
 type SchedulerInstance<I, O> = InstanceType<typeof Scheduler<I, O>>;
 type ISwarmed<I, O> = SchedulerInstance<I, O>["doRequest"] & {
@@ -15,20 +15,22 @@ type ISwarmedWithResourceSaving<I, O> = ISwarmed<I, O> & {
 
 export function swarm<I, O>(
   workerMaker: TWorkerMaker,
-  args: { maxCount?: number; recyclable?: true }
+  args?: Omit<IConfigOpts, 'recyclable'> & { recyclable?: true }
 ): ISwarmedWithResourceSaving<I, O>;
 export function swarm<I, O>(
   workerMaker: TWorkerMaker,
-  args: { maxCount?: number; recyclable: false }
+  args?: Omit<IConfigOpts, 'recyclable'> & { recyclable: false }
 ): ISwarmed<I, O>;
 export function swarm<I = any, O = any>(
   workerMaker: TWorkerMaker,
   {
     maxCount = 3,
     recyclable = true,
-  }: { maxCount?: number; recyclable?: boolean } = {}
+    minCount = 0,
+    immediate = false,
+  }: IConfigOpts = {}
 ) {
-  const scheduler = new Scheduler<I, O>(workerMaker, maxCount, recyclable);
+  const scheduler = new Scheduler<I, O>(workerMaker, maxCount, minCount, immediate, recyclable);
 
   if (recyclable) {
     const swarmed: ISwarmedWithResourceSaving<I, O> = (req) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,3 +9,10 @@ export interface IQueueRequest<I, O> {
 }
 
 export type TWorkerMaker = () => Worker;
+
+export interface IConfigOpts {
+  maxCount?: number;
+  minCount?: number;
+  immediate?: boolean;
+  recyclable?: boolean;
+}


### PR DESCRIPTION
…cling

+ `minAlive` -- describes the minimum number of worker instances to keep when recycling runs. This has little meaning when recycling is disabled.
+ `immediate` -- when *true*, either `minAlive` or `maxTotal` (when `minAlive` is 0)  worker instances will be spawned right away.