### PR TITLE
provide a way to subscribe events emitted by worker

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -4,12 +4,36 @@ import { IQueueRequest, TInterruptableReq } from "./types";
 export class Handler<I, O> {
   private working = false;
   private retireRequested = false;
+  private errorEvtHandler: (ev: ErrorEvent) => any;
+  private messageEvtHandler: (ev: MessageEvent) => any;
+  private messageerrorEvtHandler: (ev: MessageEvent) => any;
 
   constructor(
     private scheduler: Scheduler<I, O>,
     private worker: Worker,
     private _id: string
-  ) {}
+  ) {
+    this.errorEvtHandler = (ev) => {
+      this.scheduler.workerEvents.dispatchEvent(new CustomEvent('error', {
+        detail: ev
+      }));
+    };
+    this.worker.addEventListener('error', this.errorEvtHandler);
+
+    this.messageEvtHandler = (ev) => {
+      this.scheduler.workerEvents.dispatchEvent(new CustomEvent('message', {
+        detail: ev
+      }));
+    };
+    this.worker.addEventListener('message', this.messageEvtHandler);
+
+    this.messageerrorEvtHandler = (ev) => {
+      this.scheduler.workerEvents.dispatchEvent(new CustomEvent('messageerror', {
+        detail: ev
+      }));
+    };
+    this.worker.addEventListener('messageerror', this.messageerrorEvtHandler);
+  }
 
   public handle(
     req: IQueueRequest<I, O>["details"],
@@ -25,6 +49,10 @@ export class Handler<I, O> {
   }
 
   public destroy() {
+    this.worker.removeEventListener('error', this.errorEvtHandler);
+    this.worker.removeEventListener('message', this.messageEvtHandler);
+    this.worker.removeEventListener('messageerror', this.messageerrorEvtHandler);
+
     this.worker.terminate();
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,3 +16,5 @@ export interface IConfigOpts {
   immediate?: boolean;
   recyclable?: boolean;
 }
+
+export type TWorkerEventHandler = <K extends keyof WorkerEventMap>(evtType: K, handler: (evt: WorkerEventMap[K]) => any) => () => void


### PR DESCRIPTION
+ for advanced usage, the default promise api won't help with main thread passively receiving messages emitted by worker instances. Thus, introducing a new API, `onWorkerEvent`, that allows `addEventListener`-alike subscription to the worker instances.